### PR TITLE
feat: Add Candidate, PR, and PRMapping models with relationships

### DIFF
--- a/Models/ApplicationDbContext.cs
+++ b/Models/ApplicationDbContext.cs
@@ -1,12 +1,18 @@
 using Microsoft.EntityFrameworkCore;
+// using shortlist.Models; // Will use JobShortage.Models for all
 
-namespace JobShortage.Models
+namespace JobShortage.Models // Assuming this namespace is correct for the existing models
 {
     public class ApplicationDbContext : DbContext
     {
         public DbSet<Applicant> Applicants { get; set; }
         public DbSet<JobDescription> JobDescriptions { get; set; }
         public DbSet<Shortage> Shortages { get; set; }
+
+        // New DbSets for Candidate, PR, and PRMapping
+        public DbSet<Candidate> Candidates { get; set; } = null!;
+        public DbSet<PR> PRs { get; set; } = null!;
+        public DbSet<PRMapping> PRMappings { get; set; } = null!;
 
         public ApplicationDbContext(DbContextOptions<ApplicationDbContext> options) : base(options)
         {
@@ -27,6 +33,20 @@ namespace JobShortage.Models
                 .HasMany(jd => jd.Shortages)
                 .WithOne(s => s.JobDescription)
                 .HasForeignKey(s => s.JobDescriptionId);
+
+            // Configure Candidate -> PRMapping (One-to-Many)
+            modelBuilder.Entity<Candidate>()
+                .HasMany(c => c.PRMappings)
+                .WithOne(prm => prm.Candidate)
+                .HasForeignKey(prm => prm.CandidateId)
+                .OnDelete(DeleteBehavior.Cascade); // Optional: define delete behavior
+
+            // Configure PR -> PRMapping (One-to-Many)
+            modelBuilder.Entity<PR>()
+                .HasMany(p => p.PRMappings)
+                .WithOne(prm => prm.PR)
+                .HasForeignKey(prm => prm.PRId)
+                .OnDelete(DeleteBehavior.Cascade); // Optional: define delete behavior
         }
     }
 }

--- a/Models/Candidate.cs
+++ b/Models/Candidate.cs
@@ -1,0 +1,15 @@
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+
+namespace JobShortage.Models // Changed namespace
+{
+    public class Candidate
+    {
+        [Key]
+        public int Id { get; set; }
+
+        // Other candidate properties can be added here
+
+        public ICollection<PRMapping> PRMappings { get; set; } = new List<PRMapping>();
+    }
+}

--- a/Models/PR.cs
+++ b/Models/PR.cs
@@ -1,0 +1,15 @@
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+
+namespace JobShortage.Models // Changed namespace
+{
+    public class PR
+    {
+        [Key]
+        public int Id { get; set; }
+
+        // Other PR properties can be added here
+
+        public ICollection<PRMapping> PRMappings { get; set; } = new List<PRMapping>();
+    }
+}

--- a/Models/PRMapping.cs
+++ b/Models/PRMapping.cs
@@ -1,0 +1,21 @@
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+
+namespace JobShortage.Models // Changed namespace
+{
+    public class PRMapping
+    {
+        [Key]
+        public int Id { get; set; }
+
+        public int CandidateId { get; set; }
+        [ForeignKey("CandidateId")]
+        public Candidate Candidate { get; set; } = null!;
+
+        public int PRId { get; set; }
+        [ForeignKey("PRId")]
+        public PR PR { get; set; } = null!;
+
+        // Other mapping specific properties can be added here
+    }
+}


### PR DESCRIPTION
- Created Candidate, PR, and PRMapping entity classes.
- Established one-to-many relationships between Candidate/PR and PRMapping.
- Updated ApplicationDbContext to include the new entities and configure their relationships using Fluent API.
- Standardized namespace for all models to JobShortage.Models.